### PR TITLE
Update package versions in Api and Client projects

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
     <PackageReference Include="Supabase" Version="1.1.1" />

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Blazor-ApexCharts" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.4" PrivateAssets="all" />
     <PackageReference Include="MudBlazor" Version="8.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Bump Microsoft.Azure.Functions.Worker.Sdk to 2.0.2 in Api.csproj.
- Remove non-visible character in Client.csproj project SDK line.
- Upgrade Microsoft.AspNetCore.Components.WebAssembly to 9.0.4.
- Upgrade Microsoft.AspNetCore.Components.WebAssembly.DevServer to 9.0.4.